### PR TITLE
Fix failing dependency request in the CollectMetrics function

### DIFF
--- a/Templates/azuredeploy.json
+++ b/Templates/azuredeploy.json
@@ -1053,6 +1053,10 @@
               {
                 "name": "HttpTriggerFunction",
                 "value": "[parameters('httpTriggerFunction')]"
+              },
+              {
+                "name": "WEBSITE_LOAD_USER_PROFILE",
+                "value": "[if(parameters('createEventHubs'), 1, 0)]" // this is required for proper certificate loading in the CollectMetrics function
               }
             ]
           }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
From time to time there is an error in the CollectMetrics function when doing POST request to the OMS endpoint `/AgentService.svc`: 
```
exception occurred : System.AggregateException: One or more errors occurred. (The SSL connection could not be established, see inner exception.)
 ---> System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
 ---> System.ComponentModel.Win32Exception (0x8009030D): The credentials supplied to the package were not recognized
```

This seems to be a problem with loading certificates. 
>  In order to load a PFX from the file system, a user profile needs to be available for the web application due to how Windows loads certificates from files. 

Full documentation [here](https://azure.microsoft.com/en-in/blog/pdf-generation-and-loading-file-based-certificates-in-azure-websites/).

In order to fix it we need to set `WEBSITE_LOAD_USER_PROFILE` to `1` when using the CollectMetrics function.

Solution tested in multiple environments, and there is no more errors with this setting.



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run `.\Scripts\deploy.ps1` 
* When enabling Monitoring architecture, check the Function App Configuration, it should have `WEBSITE_LOAD_USER_PROFILE` set to `1`
* Go to Application Insights and run the following query (if using Classic Application Insights)
```
dependencies
| where operation_Name == "CollectMetrics"
| where name == "POST /AgentService.svc"
| summarize count =count() by resultCode, bin(timestamp, 5min)
| render columnchart 
```

If using Workspace based Application Insights, run 
```
AppDependencies
| where OperationName == "CollectMetrics"
| where Name == "POST /AgentService.svc"
| summarize count =count() by ResultCode, bin(TimeGenerated, 5min)
| render columnchart 
```

After applying the setting, you shouldn't have any `Faulted` result from the ` /AgentService.svc` endpoint, like in the following screenshot:
![image](https://user-images.githubusercontent.com/25376553/142378995-e27d7ff4-c515-4c2b-aaa2-61a5c9929d96.png)

