### PR TITLE
Restrict permissions for log upload SAS token

### DIFF
--- a/FunctionApp/FunctionApp/InvokeUploadModuleLogs.cs
+++ b/FunctionApp/FunctionApp/InvokeUploadModuleLogs.cs
@@ -189,7 +189,7 @@ namespace FunctionApp
             };
 
             // Specify permissions for the SAS.
-            sasBuilder.SetPermissions(BlobAccountSasPermissions.All);
+            sasBuilder.SetPermissions(BlobAccountSasPermissions.Write | BlobAccountSasPermissions.Create);
           
             // Add the SAS token to the container URI.
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(blobContainerClient.Uri)


### PR DESCRIPTION
## Purpose
The SAS token which is used by the edgeAgent to upload logs to the storage container does not need full permission. It only need write access as specified in the documention here: https://docs.microsoft.com/en-us/azure/iot-edge/how-to-retrieve-iot-edge-logs?view=iotedge-2020-11#upload-module-logs

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... 
```

## How to Test
* Get the code
* Deploy FunctionApp to Azure Fuction
* Ensure a device is configured for module log upload

## What to Check
* See module logs are still uploadede and processed

## Other Information
This fixes a hypothetical security issue where a SAS token that is captured by a bad actor could be used to read the logs of other devices. Hypothetical because the logs are removed from the storage account as soon as they are processed.